### PR TITLE
Made it so that we use the region that is passed in with the requestO…

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var RequestSigner = function(requestOpts, credentials) {
     if(!this.request.headers) this.request.headers = {}
     this.credentials = credentials
     this.service = 'execute-api'
-    this.region = this.region ? this.region : 'us-west-2'
+    this.region = requestOpts.region ? requestOpts.region : 'us-west-2'
     
 	this._request = {
 		query: '',


### PR DESCRIPTION
In order to use this solution with AWS API Gateway, I need to make it so we could pass in a region. So, I made it that it checks for a region in the requestOpts and if it exists use it, else use your "us-west-2".